### PR TITLE
feat: ImGuiHovered여부 렌더매니저에 전달, 마우스imgui위에 있을경우 이동키 적용안되도록 수정 

### DIFF
--- a/Project/Client/ImGuiMgr.cpp
+++ b/Project/Client/ImGuiMgr.cpp
@@ -7,6 +7,7 @@
 #include <Engine\CPathMgr.h>
 
 #include <Engine\CGameObject.h>
+#include <Engine\CRenderMgr.h>
 
 #include "UI.h"
 #include "ParamUI.h"
@@ -129,6 +130,11 @@ void ImGuiMgr::finaltick()
 
     if (KEY_TAP(KEY::ENTER))
         ImGui::SetWindowFocus(nullptr);
+
+    if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+        CRenderMgr::GetInst()->SetIsImGuiHovered(true);
+    else
+        CRenderMgr::GetInst()->SetIsImGuiHovered(false);
 }
 
 void ImGuiMgr::render()

--- a/Project/Engine/CRenderMgr.cpp
+++ b/Project/Engine/CRenderMgr.cpp
@@ -22,6 +22,7 @@ CRenderMgr::CRenderMgr()
     : m_Light2DBuffer(nullptr)
     , RENDER_FUNC(nullptr)
     , m_pEditorCam(nullptr)
+    , b_IsImGuiHovered(false)
 {
     Vec2 vResolution = CDevice::GetInst()->GetRenderResolution();
     m_RTCopyTex = CResMgr::GetInst()->CreateTexture(L"RTCopyTex"
@@ -64,7 +65,6 @@ void CRenderMgr::render()
 
     // 광원 및 전역 데이터 업데이트 및 바인딩
     UpdateData();
-
 
     // 기즈모 선택된 상태 정리
     m_bGizmoObjectChanged = false;

--- a/Project/Engine/CRenderMgr.h
+++ b/Project/Engine/CRenderMgr.h
@@ -32,8 +32,9 @@ private:
     CGameObject*                m_GizMoTargetObject;  //기즈모가 생겨야할 타겟 오브젝트
     bool                        m_bGizmoObjectChanged;
 
+    bool                        b_IsImGuiHovered; //Imgui와 상호작용중인 상태라면 특정 키를 안먹히도록 하는데 사용
+   
     Ptr<CTexture>               m_RTCopyTex;
-
 
     void (CRenderMgr::* RENDER_FUNC)(void);
 
@@ -70,6 +71,9 @@ public:
 
 
     const vector<CLight3D*> GetLight3D() { return m_vecLight3D; }
+
+    bool GetIsImGuiHovered() { return b_IsImGuiHovered; }
+    void SetIsImGuiHovered(bool _IsHovered) { b_IsImGuiHovered = _IsHovered; }
 
 public:
     CGameObject* GetGizMoTargetObj() { return m_GizMoTargetObject; }   //기즈모가 생겨야할 타겟오브젝트 게터, 세터 함수

--- a/Project/Script/CPlayerScript.cpp
+++ b/Project/Script/CPlayerScript.cpp
@@ -4,6 +4,7 @@
 #include <Engine\CMeshRender.h>
 #include <Engine\CMaterial.h>
 #include <Engine\CPathFinder.h>
+#include <Engine\CRenderMgr.h>
 
 #include <fstream>
 
@@ -28,9 +29,9 @@ void CPlayerScript::begin()
 
 void CPlayerScript::tick()
 {
-
+	//ImGui::IsWindowHovered()
 	CLevelMgr::GetInst()->GetCurLevel()->FindObjectByName(L"Test");
-	if (KEY_TAP(KEY::RBTN))
+	if (KEY_TAP(KEY::RBTN) && !CRenderMgr::GetInst()->GetIsImGuiHovered())
 	{
 		GetOwner()->PathFinder()->FindPathMousePicking();
 	}


### PR DESCRIPTION
bool변수로 imgui창위에 마우스가 있는지 상태값을 rendermgr에 bool변수로 전달하고, 플레이어 스크립트에서 이동 클릭 && imgui 창위에 마우스가 없을경우에만 이동되도록 해주었습니다. 자세한건 렌더매니저, 플레이어 스크립트쪽 참고하시면 될것같아요